### PR TITLE
use image_url instead of static image name for asset pipeline to work

### DIFF
--- a/lib/lazyload-rails.rb
+++ b/lib/lazyload-rails.rb
@@ -51,7 +51,7 @@ ActionView::Helpers::AssetTagHelper.module_eval do
     img = Nokogiri::HTML::DocumentFragment.parse(image_html).at_css("img")
 
     img["data-original"] = img["src"]
-    img["src"] = Lazyload::Rails.configuration.placeholder
+    img["src"] = image_url(Lazyload::Rails.configuration.placeholder)
 
     img.to_s.html_safe
   end


### PR DESCRIPTION
If you're using Rails' asset pipeline to generate the empty image, you need to use the image_url method so that it appends the hash to it, otherwise Rails won't find the file after asset compilation.