### PR TITLE
add always lazy load

### DIFF
--- a/lib/lazyload-rails.rb
+++ b/lib/lazyload-rails.rb
@@ -38,7 +38,7 @@ ActionView::Helpers::AssetTagHelper.module_eval do
     options, args = extract_options_and_args(*attrs)
     image_html = rails_image_tag(*args)
 
-    if options[:lazy]
+    if options[:lazy] || Lazyload::Rails.configuration.always_lazy
       to_lazy_image(image_html)
     else
       image_html

--- a/lib/lazyload-rails/configuration.rb
+++ b/lib/lazyload-rails/configuration.rb
@@ -20,9 +20,18 @@ module Lazyload
         @placeholder = new_placeholder
       end
 
+      # When set to true
+      def always_lazy=(always_lazy_value)
+        @always_lazy = always_lazy_value
+      end
+      def always_lazy
+        @always_lazy
+      end
+
       # Set default settings
       def initialize
         @placeholder = "http://www.appelsiini.net/projects/lazyload/img/grey.gif"
+        @always_lazy = false
       end
     end
   end

--- a/lib/lazyload-rails/version.rb
+++ b/lib/lazyload-rails/version.rb
@@ -1,5 +1,5 @@
 module Lazyload
   module Rails
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
Add a configuration option for always lazy loading image tags

If you have an existing project and don't want to adjust every single image tag this option will make every image_tag  a lazy loading image tag. 