### PR TITLE
Config option for adding css class to image elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Lazyload::Rails.configure do |config|
   # This can be easily customized:
   config.placeholder = "/public/img/grey.gif"
 
+  # All lazyload images can have an additional classes added to them for easy DOM querying
+  config.lazy_css_class = "lazy_images"
+
   # image_tag can return lazyload-friendly images by default,
   # no need to pass the { lazy: true } option
   config.lazy_by_default = true

--- a/lib/lazyload-rails.rb
+++ b/lib/lazyload-rails.rb
@@ -54,6 +54,10 @@ ActionView::Helpers::AssetTagHelper.module_eval do
     img["data-original"] = img["src"]
     img["src"] = Lazyload::Rails.configuration.placeholder
 
+    if Lazyload::Rails.configuration.lazy_css_class
+      img["class"] = img["class"].present? ? img["class"].to_s + " " + Lazyload::Rails.configuration.lazy_css_class : Lazyload::Rails.configuration.lazy_css_class 
+    end
+
     img.to_s.html_safe
   end
 

--- a/lib/lazyload-rails/config.rb
+++ b/lib/lazyload-rails/config.rb
@@ -28,10 +28,19 @@ module Lazyload
         @lazy_by_default
       end
 
+      # When { lazy: true } image_tag will include the lazy_css_class
+      def lazy_css_class
+        @lazy_css_class
+      end
+      def lazy_css_class=(lazy_css_class)
+        @lazy_css_class = lazy_css_class
+      end
+
       # Set default settings
       def initialize
         @placeholder = "data:image/gif;base64,R0lGODdhAQABAPAAAMPDwwAAACwAAAAAAQABAAACAkQBADs="
         @lazy_by_default = false
+        @lazy_css_class = nil
       end
     end
   end

--- a/test/test_image_tag.rb
+++ b/test/test_image_tag.rb
@@ -9,9 +9,10 @@ class TestImageTag < ::ActionView::TestCase
   end
 
   def test_lazy_option_sets_lazy_attributes
-    img = parse(image_tag("foo.png", size: "101x151", lazy: true))
+    img = parse(image_tag("foo.png", size: "101x151", class: "foo",lazy: true))
 
     assert_match %r(^.*foo.png$), img["data-original"]
+    assert_equal "foo", img["class"]
     assert_equal "151", img["height"]
     assert_equal "101", img["width"]
   end
@@ -64,6 +65,7 @@ class TestImageTag < ::ActionView::TestCase
       { size: "100x150" }
     ].each do |opts|
       img = parse(image_tag("foo.png", size: "100x150", lazy: false))
+
       assert_equal "150", img["height"]
       assert_equal "100", img["width"]
     end
@@ -73,7 +75,34 @@ class TestImageTag < ::ActionView::TestCase
     img = parse(image_tag("foo.png"))
 
     assert_nil img["data-original"]
+    assert_nil img["class"]
     assert_match %r(^.*foo.png$), img["src"]
+  end
+
+  def test_lazy_css_class
+    Lazyload::Rails.configure do |config|
+      config.lazy_css_class = "lazy-img"
+    end
+    img = parse(image_tag("foo.png", lazy: true))
+    assert_equal "lazy-img", img["class"]
+  end
+
+  def test_lazy_css_class_with_class_already_assigned
+    Lazyload::Rails.configure do |config|
+      config.lazy_css_class = "lazy-img"
+    end
+    img = parse(image_tag("foo.png", class: "foo", lazy: true))
+    assert_equal "foo lazy-img", img["class"]
+  end
+
+  def test_class_with_lazy_css_class_nil
+    img = parse(image_tag("foo.png", class: "foo", lazy: true))
+    assert_equal "foo", img["class"]
+  end
+
+  def test_lazy_css_class_nil
+    img = parse(image_tag("foo.png", lazy: true))
+    assert_nil img["class"]
   end
 
   private


### PR DESCRIPTION
We wanted to be able to target images using a selector that are marked with lazy. This commit introduces a configuration option called "lazy_css_class" that if set will be added to all images with lazy: true. It defaults to nil so existing functionality won't change.